### PR TITLE
Provide notice when bucket list is being truncated

### DIFF
--- a/app/dashboard/buckets.partial.html
+++ b/app/dashboard/buckets.partial.html
@@ -17,9 +17,13 @@
 -->
 <div class="panel panel-default" ng-repeat="bucket in buckets.buckets">
 	<div class="panel-heading">
-    	<h3 class="panel-title">Bucket: {{bucket.name}} <span class="badge">{{bucket.size}}</span></h3>
+    	<h3 class="panel-title">Bucket: {{bucket.name}} <span class="badge">{{bucket.size}}<span ng-hide="!bucket.truncated">+</span></span></h3>
 	</div>
 	<div class="panel-body">
+		<div class="alert alert-info" role="alert" ng-hide="!bucket.truncated">
+			Bucket listing is limited to 1000 objects, visit AWS console to see all items or <strong><a href ng-click="downloadModal(bucket.name)">download all objects</a></strong> locally
+		</div>
+		
 		<strong>Download All: </strong><a href ng-click="downloadModal(bucket.name)"><span class="glyphicon glyphicon-cloud-download"></span></a>
 		<div ng-messages="bucket.errors">
 			<div ng-message="error" class="alert alert-danger" role="alert">Error occurred, we can attempt to <a href brenda-help="dashboard/help/s3cors.html"><strong>fix it</strong></a></div>

--- a/app/dashboard/dashboardParent.ctrl.js
+++ b/app/dashboard/dashboardParent.ctrl.js
@@ -63,6 +63,8 @@ angular.module('dashboard')
 						b.errors = {};
 						b.files = [];
 						b.size = data.Contents.length;
+						b.truncated = data.IsTruncated;
+						
 						data.Contents.forEach(function(obj) {
 							var url = awsService.getObjectUri(b.name, obj.Key);
 							b.files.push({name: obj.Key, size: obj.Size, modified: obj.LastModified, url: url, caption: obj.Key});


### PR DESCRIPTION
There is no great way to perform pagination on the s3 bucket object
list so for now we’ll simply provide a notice that there are additional
items